### PR TITLE
💚 Fix building python clients

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,3 +24,9 @@ jobs:
         run: go test --coverprofile cover.out ./pdp ./attributes
       - name: Check coverage meets threshold
         run: overcover --coverprofile cover.out ./pdp ./attributes --threshold ${{ env.COVERAGE_THRESH_PCT }}
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Validate python project files
+        
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /server
 /vendor/
 *.out
+/clients/python/*/dist/

--- a/clients/python/accesspdp/pyproject.toml
+++ b/clients/python/accesspdp/pyproject.toml
@@ -8,9 +8,10 @@ description = "A Python gRPC client for Virtru's Access PDP"
 requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: BSD 3 Clause",
+    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
 ]
+license_expression = "BSD-3-Clause"
 
 dependencies = [
   'grpcio',

--- a/clients/python/attributes/pyproject.toml
+++ b/clients/python/attributes/pyproject.toml
@@ -8,9 +8,11 @@ description = "Python protobuf definitions for OpenTDF ABAC attributes"
 requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: BSD 3 Clause",
+    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
 ]
+license_expression = "BSD-3-Clause"
+
 dependencies = [
   'grpcio',
   'protobuf',


### PR DESCRIPTION

### Proposed Changes

### Checklist

- Invalid trove classifier, BSD 3 Clause. See list here: https://pypi.org/classifiers/
- Since this is ambiguous, this adds a license_expression per https://peps.python.org/pep-0639
- Notably, since these never would build, there isn't a need to update a version number since they must never have deployed

### Testing Instructions

