### PR TITLE
Fix build by adding a `run` clause to the action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,5 +28,4 @@ jobs:
         with:
           python-version: '3.10'
       - name: Validate python project files
-        
-
+        run: python3 -m compileall ./clients/python


### PR DESCRIPTION
### Proposed Changes

### Checklist

- [x] I have included `#major/#minor/#patch` tags in commit messages for commits that make major, minor or patch changes, so the [autoreleaser](https://github.com/anothrNick/github-tag-action#bumping) can appropriately bump the package version

### Testing Instructions

